### PR TITLE
land-nodeの数を変更するサンプルを追加した

### DIFF
--- a/k8s.go
+++ b/k8s.go
@@ -19,14 +19,14 @@ func updateReplicas(namespace string, name string, replicas int32) error {
 		return errors.Wrap(err, "failed kubernetes.NewForConfig")
 	}
 
-	deployment, err := clientset.AppsV1beta2().Deployments(namespace).Get(name, metav1.GetOptions{})
+	deployment, err := clientset.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		fmt.Printf("failed get Deployment %+v\n", err)
 		return errors.Wrap(err, "failed get deployment")
 	}
 	deployment.Spec.Replicas = &replicas
 	fmt.Printf("Deployment %v\n", deployment)
-	ug, err := clientset.AppsV1beta2().Deployments(deployment.Namespace).Update(deployment)
+	ug, err := clientset.AppsV1().Deployments(deployment.Namespace).Update(deployment)
 	if err != nil {
 		fmt.Printf("failed update Deployment %+v", err)
 		return errors.Wrap(err, "failed update Deployment")

--- a/k8s/deployment-editor-role.yaml
+++ b/k8s/deployment-editor-role.yaml
@@ -4,6 +4,6 @@ metadata:
   namespace: default
   name: deployment-editor
 rules:
-- apiGroups: [""]
+- apiGroups: ["extensions", "apps"]
   resources: ["deployments"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/k8s/deployment-editor-role.yaml
+++ b/k8s/deployment-editor-role.yaml
@@ -1,0 +1,9 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: deployment-editor
+rules:
+- apiGroups: [""]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/k8s/deployment-editor-rolebinding.yaml
+++ b/k8s/deployment-editor-rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: editor-deployment
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: deployment-editor
+  apiGroup: rbac.authorization.k8s.io

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func (ppm *PlayerPositionManager) existActivePlayer() bool {
 }
 
 func main() {
-	err := updateReplicas("default", "land", 0)
+	err := updateReplicas("default", "land-node", 0)
 	if err != nil {
 		fmt.Printf("error:%+v\n", err)
 	}

--- a/main.go
+++ b/main.go
@@ -36,16 +36,18 @@ func (ppm *PlayerPositionManager) existActivePlayer() bool {
 }
 
 func main() {
-	err := updateReplicas("default", "land-node", 0)
-	if err != nil {
-		fmt.Printf("error:%+v\n", err)
-	}
-
 	for {
 		t := time.NewTicker(10 * time.Second) // TODO 5 * time.Minute
 		for {
 			select {
 			case <-t.C:
+				err := updateReplicas("default", "land-node", 1)
+				if err != nil {
+					fmt.Printf("error:%+v\n", err)
+					continue
+				}
+				fmt.Println("done updateReplicas.")
+
 				log := slog.Start(time.Now())
 				go func(log *slog.Log) {
 					ppm := PlayerPositionManager{

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	for {
-		t := time.NewTicker(5 * time.Minute)
+		t := time.NewTicker(10 * time.Second) // TODO 5 * time.Minute
 		for {
 			select {
 			case <-t.C:


### PR DESCRIPTION
# Error Message

```
failed get Deployment deployments.apps "land-node" is forbidden: User "system:serviceaccount:default:default" cannot get deployments.apps in the namespace "default": Unknown user "system:serviceaccount:default:default"
```

# RBACによるRoleの設定

## まずは自分にcludster-adminをつける

https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control?hl=en#prerequisites_for_using_role-based_access_control

```
kubectl create clusterrolebinding cluster-admin-binding \
--clusterrole cluster-admin --user $(gcloud config get-value account)
```

## default saにdeployments.editorを設定してみたつもりだが・・・

https://stackoverflow.com/questions/47973570/kubernetes-log-user-systemserviceaccountdefaultdefault-cannot-get-services

